### PR TITLE
spring is a dependency of spring-commands-cucumber.

### DIFF
--- a/spring-commands-cucumber.gemspec
+++ b/spring-commands-cucumber.gemspec
@@ -17,6 +17,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "spring", ">= 0.9.0"
+
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
Hi Jon, thanks for Spring! I hope it makes it into Rails 4.1.

Anyhow, I'd like to have my Gemfile read just

``` ruby
gem "spring-commands-cucumber"
```

instead of

``` ruby
gem "spring-commands-cucumber"
gem "spring"
```

Seems redundant to have to specify `spring` as well. What do you think?
