### PR TITLE
copy rake spring command as cucumber command,, fixes compatibility with ...

### DIFF
--- a/lib/spring/commands/cucumber.rb
+++ b/lib/spring/commands/cucumber.rb
@@ -1,16 +1,30 @@
 module Spring
   module Commands
     class Cucumber
-      def env(*)
-        "test"
+      class << self
+        attr_accessor :environment_matchers
       end
 
-      def exec_name
-        "cucumber"
+      self.environment_matchers = {
+        :default     => "test",
+        /^test($|:)/ => "test"
+      }
+
+      def env(args)
+        # This is an adaption of the matching that Rake itself does.
+        # See: https://github.com/jimweirich/rake/blob/3754a7639b3f42c2347857a0878beb3523542aee/lib/rake/application.rb#L691-L692
+        if env = args.grep(/^(RAILS|RACK)_ENV=(.*)$/m).last
+          return env.split("=").last
+        end
+
+        self.class.environment_matchers.each do |matcher, environment|
+          return environment if matcher === (args.first || :default)
+        end
+
+        nil
       end
     end
 
     Spring.register_command "cucumber", Cucumber.new
-    Spring::Commands::Rake.environment_matchers[/^cucumber($|:)/] = "test"
   end
 end


### PR DESCRIPTION
- Works with Spring 1.1.3
- Used spring's rake command as template
- Now support RAILS_ENV

Closes #2, #3
