### PR TITLE
Fix environment matcher to work with a cucumber path argument

### DIFF
--- a/lib/spring/commands/cucumber.rb
+++ b/lib/spring/commands/cucumber.rb
@@ -7,7 +7,7 @@ module Spring
 
       self.environment_matchers = {
         :default     => "test",
-        /^features/  => "test" # if a path is passed, make sure the default env is applied
+        /^features($|\/)/  => "test" # if a path is passed, make sure the default env is applied
       }
 
       def env(args)

--- a/lib/spring/commands/cucumber.rb
+++ b/lib/spring/commands/cucumber.rb
@@ -7,7 +7,8 @@ module Spring
 
       self.environment_matchers = {
         :default     => "test",
-        /^test($|:)/ => "test"
+        /^test($|:)/ => "test",
+        /^features/  => "test" # if a path is passed, make sure the default env is applied
       }
 
       def env(args)

--- a/lib/spring/commands/cucumber.rb
+++ b/lib/spring/commands/cucumber.rb
@@ -7,7 +7,6 @@ module Spring
 
       self.environment_matchers = {
         :default     => "test",
-        /^test($|:)/ => "test",
         /^features/  => "test" # if a path is passed, make sure the default env is applied
       }
 


### PR DESCRIPTION
Removes the matcher that only works with Rake and replaces it with a matcher for a feature path. Fixes #5.
