### PR TITLE
Replace Rake env variable handling with usual

### DIFF
--- a/lib/spring/commands/cucumber.rb
+++ b/lib/spring/commands/cucumber.rb
@@ -6,16 +6,12 @@ module Spring
       end
 
       self.environment_matchers = {
-        :default     => "test",
-        /^features($|\/)/  => "test" # if a path is passed, make sure the default env is applied
+        :default => "test",
+        /^features($|\/)/ => "test" # if a path is passed, make sure the default env is applied
       }
 
       def env(args)
-        # This is an adaption of the matching that Rake itself does.
-        # See: https://github.com/jimweirich/rake/blob/3754a7639b3f42c2347857a0878beb3523542aee/lib/rake/application.rb#L691-L692
-        if env = args.grep(/^(RAILS|RACK)_ENV=(.*)$/m).last
-          return env.split("=").last
-        end
+        return ENV['RAILS_ENV'] if ENV['RAILS_ENV']
 
         self.class.environment_matchers.each do |matcher, environment|
           return environment if matcher === (args.first || :default)


### PR DESCRIPTION
Current, Rake-way env variable handling should not be applied, because `cucumber` itself doesn't work this way.

For example, to start cucumber in different environment, I had to do:

``` bash
$ bin/spring cucumber RAILS_ENV=cucumber
```

While usual way would be:

``` bash
$ RAILS_ENV=cucumber bin/spring cucumber
# or
$ export RAILS_ENV=cucumber
$ bin/spring cucumber
```

Instead of parsing arguments, spring-commands-cucumber should check for `ENV['RAILS_ENV']`. With this approach, you can automatically set environment by adding something like this to `config/spring.rb`:

``` ruby
if ARGV.first == 'cucumber'
  ENV['RAILS_ENV'] = 'cucumber'
end
```
